### PR TITLE
配置文件中添加对字体、背景等的颜色的设定

### DIFF
--- a/srcs/flipclock.c
+++ b/srcs/flipclock.c
@@ -271,12 +271,12 @@ void flipclock_load_conf(struct flipclock *app)
 		      "# Uncomment `font = ` and "
 		      "add path to use custom font.\n"
 		      "#font = \n"
-					"# Uncomment `font_color = ` to modify the color of font.\n"
-					"#font_color = #d0d0d0ff\n"
-					"# Uncomment `rect_color = ` to modify the color of rectangle.\n"
-					"#rect_color = #202020ff\n"
-					"# Uncomment `black_color = ` to modify the color of black.\n"
-					"#black_color = #000000ff\n",
+		      "# Uncomment `font_color = ` to modify the color of font.\n"
+		      "#font_color = #d0d0d0ff\n"
+		      "# Uncomment `rect_color = ` to modify the color of rectangle.\n"
+		      "#rect_color = #202020ff\n"
+		      "# Uncomment `black_color = ` to modify the color of black.\n"
+		      "#black_color = #000000ff\n",
 		      conf);
 		goto close_file;
 	}


### PR DESCRIPTION
感谢您的开发！

如题所述，在配置文件中添加了 `font_color`, `rect_color` 和 `black_color` 的选项，允许用户使用 `#rrggbb[aa]` 的方式来设定字体、圆角矩形区域和背景的颜色。

目前只在 Linux (Arch Linux, Linux 5.10.11, sway 1.5.1) 上测试过，我也没有其他平台，所以测试不了，实在是抱歉。