### PR TITLE
Fix Wayland icon on GNOME

### DIFF
--- a/dists/one.alynx.FlipClock.desktop.in
+++ b/dists/one.alynx.FlipClock.desktop.in
@@ -8,3 +8,4 @@ TryExec=@package_bindir@/flipclock
 StartupNotify=false
 Terminal=false
 Categories=Utility;Clock;
+StartupWMClass=flipclock


### PR DESCRIPTION
# Description

Add `StartupWMClass=flipclock` in the `.desktop` file to fix the icon issue on the GNOME Wayland desktop.

![Screenshot From 2025-03-18 22-13-57](https://github.com/user-attachments/assets/503f07ba-2dd5-427d-8bb1-fb03a69da8e4)
